### PR TITLE
[BUG] Improve marker visibility test

### DIFF
--- a/src/scripts/turnmarker.js
+++ b/src/scripts/turnmarker.js
@@ -9,9 +9,11 @@ let animator;
 let markerId;
 let lastTurn = '';
 
-
-Hooks.on('ready', async () => {
+Hooks.once('init', () => {
     Settings.registerSettings();
+});
+
+Hooks.once('ready', () => {
     let marker = canvas.tiles.placeables.find(t => t.data.flags.turnMarker == true);
     if (marker && marker.id) {
         markerId = marker.id;

--- a/src/scripts/turnmarker.js
+++ b/src/scripts/turnmarker.js
@@ -111,14 +111,50 @@ Hooks.on('updateToken', async (scene, updateToken, updateData) => {
     }
 });
 
-Hooks.on('updateTile', async () => {
-    if (canvas.scene.data.tokenVision) {
-        let tile = canvas.tiles.placeables.find(t => t.data.flags.turnMarker == true);
+function isVisible(tile) {
+    if (tile.data.hidden) {
+        return game.user.isGM;
+    }
+
+    if (!canvas.sight.tokenVision) {
+        return true;
+    }
+
+    if (tile._controlled) {
+        return true;
+    }
+
+    const combatant = canvas.tokens.placeables.find(t => t.id === game.combat.combatant.tokenId);
+
+    if (combatant?.data.hidden) {
+        return game.user.isGM;
+    }
+
+    if (combatant._controlled) {
+        return true;
+    }
+
+    const ratio = Settings.getRatio();
+    const w = tile.data.width / ratio;
+    const h = tile.data.height / ratio;
+    const tolerance = Math.min(w, h) / 4;
+
+    return canvas.sight.testVisibility(tile.center, { tolerance, object: tile });
+}
+
+Hooks.on('updateTile', (entity, data, options, userId) => {
+    if (data.flags.turnMarker || data.flags.startMarker) {
+        const tile = canvas.tiles.placeables.find(t => t.id === data._id);
         if (tile) {
-            let combatant = canvas.tokens.placeables.find(x => x.id == game.combat.combatant.tokenId);
-            if (combatant && !combatant.data.hidden) {
-                tile.visible = canvas.sight.testVisibility(combatant.center, { tolerance: canvas.dimensions.size / 4 });
-            }
+            tile.visible = isVisible(tile);
+        }
+    }
+});
+
+Hooks.on('sightRefresh', () => {
+    for (const tile of canvas.tiles.placeables) {
+        if (tile.data.flags.turnMarker || tile.data.flags.startMarker) {
+            tile.visible = isVisible(tile);
         }
     }
 });


### PR DESCRIPTION
I'm sure you're aware of some of the marker visibility issues. This PR addresses that.

Now the marker is visible if and only if the token would visible if it was sitting right on it. But, of course, all markers are visible if the token is controlled.

One small issue: if the marker was created with a ratio that is different from `Settings.getRatio()` when we test visibility, it's not quite working as intended. But that seems to be only the case if we change the ratio mid-combat until the next turn. So it's probably not worth the effort to make it work correctly in this particular case.