### PR TITLE
[BUG] Auto-size markers to stay 1:1 ratio

### DIFF
--- a/src/scripts/marker.js
+++ b/src/scripts/marker.js
@@ -187,12 +187,22 @@ export class Marker {
                 newWidth = newHeight = token.w * ratio;
                 break;
             default: // Gridless and Square
-                newWidth = token.w * ratio;
-                newHeight = token.h * ratio;
+                newWidth = this.getSmallerDimension(token.w, token.h) * ratio;
+                newHeight = this.getSmallerDimension(token.w, token.h) * ratio;
                 break;
         }
 
         return {w: newWidth, h: newHeight};
+    }
+
+    /**
+     * Returns the smaller dimension, so we can prevent lopsided markers when we have larger tokens on square/gridless
+     * @param width
+     * @param height
+     * @returns {*}
+     */
+    static getSmallerDimension(width, height) {
+        return width < height ? width : height;
     }
 
     /**
@@ -216,8 +226,8 @@ export class Marker {
                 newY = token.center.y - ((token.w * ratio) / 2);
                 break;
             default: // Gridless and Square
-                newX = token.center.x - ((token.w * ratio) / 2);
-                newY = token.center.y - ((token.h * ratio) / 2);
+                newX = token.center.x - ((this.getSmallerDimension(token.w, token.h) * ratio) / 2);
+                newY = token.center.y - ((this.getSmallerDimension(token.w, token.h) * ratio) / 2);
         }
 
         return {x: newX, y: newY};


### PR DESCRIPTION
UAT: Prior to fix, any tokens that don't have a 1:1 height/width will have a lopsided marker which spins weirdly.

Post fix, the marker will size to 1:1 based on the smaller dimension (width/height).

![image](https://user-images.githubusercontent.com/12780629/105538639-b597cc80-5cc1-11eb-99fd-090e87ad1ad3.png)

To replicate, just change the token size for whichever token is selected.

https://github.com/kckaiwei/TurnMarker-alt/issues/35

I ended not opting for an option since smaller is much better, and ratio will size it if you want it larger than the token "rectangle" anyways.