### PR TITLE
Enhancements to the Turn Announcement

### DIFF
--- a/src/lang/en.json
+++ b/src/lang/en.json
@@ -1,5 +1,6 @@
 {
     "tm": {
+        "announceLabel": "Turn Marker",
         "settings": {
             "button": {
                 "name": "Turn Marker Global Settings",
@@ -65,6 +66,14 @@
             "announceTokenName": {
                 "name": "Use Token Name to announce",
                 "hint": "If enabled, will use Token name instead of Actor name"
+            },
+            "announceTurnMarkerAlias": {
+                "name": "Announce as Turn Marker",
+                "hint": "If enabled, the chat message will be from Turn Marker instead of the Actor"
+            },
+            "announcePlayerNames": {
+                "name": "Announce Player Names",
+                "hint": "If enabled, the chat message will show the names of the players who control the Actor"
             },
             "customImage": {
                 "name": "Custom Image Path",

--- a/src/scripts/chatter.js
+++ b/src/scripts/chatter.js
@@ -3,17 +3,34 @@ import { Settings } from "./settings.js";
 export class Chatter {
 
     static sendTurnMessage(combatant, hideNPC_name=false) {
-        let players = [];
-        combatant.players.forEach(player => {
-            players.push(player.name);
-        });
-        if (players.length == 0) players.push("GM");
+        const announceLabel = game.i18n.localize("tm.announceLabel");
         let combatantName = combatant.actor.name;
         let aliasName = combatantName;
         if (Settings.getAnnounceTokenName()) {
             combatantName = combatant.token.name;
             aliasName = combatant.name;
         }
+
+        let announceText;
+        if (Settings.getAnnounceTurnMarkerAlias()) {
+            aliasName = announceLabel;
+            announceText = "";
+        } else {
+            announceText = `<em>${announceLabel}</em>`;
+        }
+
+        let playerNameDisplay;
+        if (Settings.getAnnouncePlayerNames()) {
+          let players = [];
+          combatant.players.forEach(player => {
+              players.push(player.name);
+          });
+          if (players.length == 0) players.push("GM");
+          playerNameDisplay = `<p>${players.join(' - ')}</p>`;
+        } else {
+          playerNameDisplay = "";
+        }
+
         if (hideNPC_name && !combatant.actor.hasPlayerOwner) {
             combatantName = "???";
         }
@@ -25,9 +42,9 @@ export class Chatter {
                 `<div class="flexrow">${this.placeImage(combatant)}
                     <div style="flex: 12;">
                         <h2>${combatantName}'s Turn</h2>
-                        <p>${players.join(' - ')}</p>
+                        ${playerNameDisplay}
                     </div>
-                    </div><em>Turn Marker</em>`
+                    </div>${announceText}`
         });
     }
 
@@ -37,7 +54,7 @@ export class Chatter {
             if (combatant.flags.core && combatant.flags.core.thumb) {
                 img = combatant.flags.core.thumb;
             }
-            return `<div style="flex:3;"><img src="${img}" style="border: none;" /></div>`;
+            return `<div style="flex:3;padding-right:4px"><img src="${img}" style="border: none;" /></div>`;
             // return `<div style="flex:3;"><video><source="${combatant.img}"></video></div>`;
         } else return '';
     }

--- a/src/scripts/settings.js
+++ b/src/scripts/settings.js
@@ -10,6 +10,8 @@ const announceActors = 'announce-Actors';
 const announceAsActor = 'announce-asActor';
 const announceImage = 'announce-image';
 const announceTokenName = 'announce-token';
+const announceTurnMarkerAlias = 'announce-turn-marker-alias';
+const announcePlayerNames = 'announce-player-names';
 
 // Turn marker constants
 const image = 'image';
@@ -164,6 +166,21 @@ export class Settings {
         return game.settings.set(modName, announceTokenName, val);
     }
 
+    static getAnnounceTurnMarkerAlias() {
+        return game.settings.get(modName, announceTurnMarkerAlias);
+    }
+
+    static setAnnounceTurnMarkerAlias(val) {
+        return game.settings.set(modName, announceTurnMarkerAlias, val);
+    }
+
+    static getAnnouncePlayerNames() {
+        return game.settings.get(modName, announcePlayerNames);
+    }
+
+    static setAnnouncePlayerNames(val) {
+        return game.settings.set(modName, announcePlayerNames, val);
+    }
     static getIncludeAnnounceImage() {
         return game.settings.get(modName, announceImage);
     }
@@ -528,6 +545,26 @@ export class Settings {
             type: Boolean,
             default: false,
             restricted: true,
+        });
+
+        game.settings.register(modName, announceTurnMarkerAlias, {
+          name: 'tm.settings.announceTurnMarkerAlias.name',
+          hint: 'tm.settings.announceTurnMarkerAlias.hint',
+          scope: 'world',
+          config: false,
+          type: Boolean,
+          default: false,
+          restricted: true,
+        });
+
+        game.settings.register(modName, announcePlayerNames, {
+          name: 'tm.settings.announcePlayerNames.name',
+          hint: 'tm.settings.announcePlayerNames.hint',
+          scope: 'world',
+          config: false,
+          type: Boolean,
+          default: true,
+          restricted: true,
         });
 
         game.settings.register(modName, customimage, {

--- a/src/scripts/settingsForm.js
+++ b/src/scripts/settingsForm.js
@@ -41,6 +41,8 @@ export class SettingsForm extends FormApplication {
             announce: Settings.shouldAnnounceTurns(),
             announceImage: Settings.getIncludeAnnounceImage(),
             announceTokenName: Settings.getAnnounceTokenName(),
+            announceTurnMarkerAlias: Settings.getAnnounceTurnMarkerAlias(),
+            announcePlayerNames: Settings.getAnnouncePlayerNames(),
             // Start Marker Settings
             startMarkerEnabled: Settings.getIsEnabled("startmarker"),
             startMarkerPath: Settings.getStartMarkerPath()
@@ -65,6 +67,8 @@ export class SettingsForm extends FormApplication {
         Settings.setAnnounceActors(d.announceActors);
         Settings.setIncludeAnnounceImage(d.announceImage);
         Settings.setAnnounceTokenName(d.announceTokenName);
+        Settings.setAnnounceTurnMarkerAlias(d.announceTurnMarkerAlias);
+        Settings.setAnnouncePlayerNames(d.announcePlayerNames);
         Settings.setIsEnabled("startmarker", d.startMarkerEnabled);
         Settings.setStartMarkerPath(d.startMarkerPath);
 

--- a/src/templates/settings.html
+++ b/src/templates/settings.html
@@ -137,6 +137,7 @@
             </select>
         </div>
    <p class="notes">{{localize 'tm.settings.announcedActors.hint'}}</p>
+   </div>
    <div class="form-group">
         <label>{{localize 'tm.settings.announceTokenName.name'}}</label>
         <div class="form-fields">
@@ -144,6 +145,19 @@
         </div>
         <p class="notes">{{localize 'tm.settings.announceTokenName.hint'}}</p>
    </div>
+   <div class="form-group">
+        <label>{{localize 'tm.settings.announceTurnMarkerAlias.name'}}</label>
+        <div class="form-fields">
+            <input name="announceTurnMarkerAlias" type="checkbox" {{#if announceTurnMarkerAlias}}checked="checked" {{/if}} />
+        </div>
+        <p class="notes">{{localize 'tm.settings.announceTurnMarkerAlias.hint'}}</p>
+   </div>
+   <div class="form-group">
+        <label>{{localize 'tm.settings.announcePlayerNames.name'}}</label>
+        <div class="form-fields">
+            <input name="announcePlayerNames" type="checkbox" {{#if announcePlayerNames}}checked="checked" {{/if}} />
+        </div>
+        <p class="notes">{{localize 'tm.settings.announcePlayerNames.hint'}}</p>
    </div>
     <hr />
     <!--Start Marker-->


### PR DESCRIPTION
This...
1. Adds a little bit of padding between the Token and the rest of the Announcement text for improved readability
2. Adds a setting to allow the Player list to be removed
3. Adds a setting to move the "Turn Marker" text from inside the chat message to the "Sender" alias, saving space and avoiding duplicate information
4. Localizes the "Turn Marker" label so it can be changed to be correct in other languages (someone will still need to actually translate it for other languages)