### PR TITLE
0.8+compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.8.0
+- Add compatibility with 0.8.6
+
 # 2.7.5
 - Fixed SWADE integration (via hook workaround)
 

--- a/src/module.json
+++ b/src/module.json
@@ -3,9 +3,9 @@
 	"title": "Turn Marker",
 	"description": "Displays a (optionally animated) marker on the token who's active turn it is. Originally by Brunhine",
 	"author": "kckaiwei",
-	"version": "2.7.4",
-	"minimumCoreVersion": "0.7.5",
-	"compatibleCoreVersion": "0.7.9",
+	"version": "2.8.0",
+	"minimumCoreVersion": "0.8.0",
+	"compatibleCoreVersion": "0.8.6",
 	"manifestPlusVersion": "1.0.0",
 	"esmodules": [
 		"scripts/turnmarker.js"
@@ -56,6 +56,6 @@
 		}
 	],
 	"url": "https://github.com/kckaiwei/TurnMarker-alt",
-	"manifest": "https://raw.githubusercontent.com/kckaiwei/TurnMarker-alt/v2.7.4/src/module.json",
-	"download": "https://github.com/kckaiwei/TurnMarker-alt/releases/download/v2.7.4/turnmarker.zip"
+	"manifest": "https://raw.githubusercontent.com/kckaiwei/TurnMarker-alt/v2.8.0/src/module.json",
+	"download": "https://github.com/kckaiwei/TurnMarker-alt/releases/download/v2.8.0/turnmarker.zip"
 }

--- a/src/scripts/chatter.js
+++ b/src/scripts/chatter.js
@@ -51,8 +51,8 @@ export class Chatter {
     static placeImage(combatant) {
         if (Settings.getIncludeAnnounceImage()) {
             let img = combatant.img;
-            if (combatant.flags.core && combatant.flags.core.thumb) {
-                img = combatant.flags.core.thumb;
+            if (combatant._actor.data.img) {
+                img = combatant._actor.data.img;
             }
             return `<div style="flex:3;padding-right:4px"><img src="${img}" style="border: none;" /></div>`;
             // return `<div style="flex:3;"><video><source="${combatant.img}"></video></div>`;

--- a/src/scripts/marker.js
+++ b/src/scripts/marker.js
@@ -12,7 +12,8 @@ export class Marker {
      */
     static async deleteTurnMarker() {
         const to_delete = canvas.scene.getEmbeddedCollection('Tile')
-            .filter(tile => tile.flags.turnMarker)
+            .filter(tile => "flags" in tile.data)
+            .filter(tile => tile.data.flags.turnMarker)
             .map(tile => tile._id);
         if (!game.user.isGM) {
             game.socket.emit(socketName, {
@@ -29,7 +30,8 @@ export class Marker {
      */
     static async deleteOnDeckMarker() {
         const to_delete = canvas.scene.getEmbeddedCollection('Tile')
-            .filter(tile => tile.flags.deckMarker)
+            .filter(tile => "flags" in tile.data)
+            .filter(tile => tile.data.flags.deckMarker)
             .map(tile => tile._id);
         if (!game.user.isGM) {
             game.socket.emit(socketName, {
@@ -56,7 +58,7 @@ export class Marker {
                 let dims = this.getImageDimensions(token, false, "turnmarker");
                 let center = this.getImageLocation(token, false, "turnmarker");
 
-                let newTile = new Tile({
+                let newTile = await canvas.scene.createEmbeddedDocuments("Tile", [{
                     img: Settings.getImagePath(),
                     width: dims.w,
                     height: dims.h,
@@ -67,11 +69,9 @@ export class Marker {
                     hidden: token.data.hidden,
                     locked: false,
                     flags: {turnMarker: true}
-                });
+                }]);
 
-                let tile = await canvas.scene.createEmbeddedEntity('Tile', newTile.data);
-
-                return tile._id;
+                return newTile._id;
             } else {
                 return null;
             }
@@ -88,7 +88,7 @@ export class Marker {
             let token = findTokenById(tokenId);
             let dims = this.getImageDimensions(token, false, "deckmarker");
             let center = this.getImageLocation(token, false, "deckmarker");
-            let newTile = new Tile({
+            let newTile = canvas.scene.createEmbeddedDocuments("Tile", [{
                 img: Settings.getOnDeckImagePath(),
                 width: dims.w,
                 height: dims.h,
@@ -99,10 +99,10 @@ export class Marker {
                 hidden: token.data.hidden,
                 locked: false,
                 flags: {deckMarker: true}
-            });
+            }]);
 
             if (game.user.isGM) {
-                await canvas.scene.createEmbeddedEntity('Tile', newTile.data);
+                await canvas.scene.createEmbeddedDocuments('Tile', newTile.data);
             }
         }
     }
@@ -113,7 +113,8 @@ export class Marker {
      */
     static async deleteStartMarker() {
         const to_delete = canvas.scene.getEmbeddedCollection('Tile')
-            .filter(tile => tile.flags.startMarker)
+            .filter(tile => "flags" in tile.data)
+            .filter(tile => tile.data.flags.startMarker)
             .map(tile => tile._id);
         if (!game.user.isGM) {
             game.socket.emit(socketName, {
@@ -137,21 +138,20 @@ export class Marker {
             let token = findTokenById(tokenId);
             let dims = this.getImageDimensions(token);
             let center = this.getImageLocation(token);
-            let newTile = new Tile({
-                img: Settings.getStartMarker(),
-                width: dims.w,
-                height: dims.h,
-                x: center.x,
-                y: center.y,
-                z: 900,
-                rotation: 0,
-                hidden: token.data.hidden,
-                locked: false,
-                flags: {startMarker: true}
-            });
 
             if (game.user.isGM) {
-                await canvas.scene.createEmbeddedEntity('Tile', newTile.data);
+                let newTile = await canvas.scene.createEmbeddedDocuments("Tile", [{
+                    img: Settings.getStartMarker(),
+                    width: dims.w,
+                    height: dims.h,
+                    x: center.x,
+                    y: center.y,
+                    z: 900,
+                    rotation: 0,
+                    hidden: token.data.hidden,
+                    locked: false,
+                    flags: {startMarker: true}
+                }]);
                 await canvas.scene.setFlag(FlagScope, Flags.startMarkerPlaced, true);
             }
         }
@@ -167,14 +167,14 @@ export class Marker {
         let dims = this.getImageDimensions(token, false, marker_type);
         let center = this.getImageLocation(token, false, marker_type);
 
-        await canvas.scene.updateEmbeddedEntity('Tile', {
+        await canvas.scene.updateEmbeddedDocuments('Tile', [{
             _id: markerId,
             width: dims.w,
             height: dims.h,
             x: center.x,
             y: center.y,
             hidden: token.data.hidden
-        });
+        }]);
     }
 
     /**

--- a/src/scripts/markeranimation.js
+++ b/src/scripts/markeranimation.js
@@ -43,19 +43,18 @@ export class MarkerAnimation {
         let tile;
         switch (marker_type) {
             case "turnmarker":
-                tile = canvas.tiles.placeables.find(t => t.data.flags.turnMarker == true);
+                tile = canvas.background.tiles.find(t => t.data.flags.turnMarker == true);
                 break;
             case "deckmarker":
-                tile = canvas.tiles.placeables.find(t => t.data.flags.deckMarker == true);
+                tile = canvas.background.tiles.find(t => t.data.flags.deckMarker == true);
                 break;
             default:
-                tile = canvas.tiles.placeables.find(t => t.data.flags.turnMarker == true);
+                tile = canvas.background.tiles.find(t => t.data.flags.turnMarker == true);
         }
-
         if (tile && tile.data.img) {
             let delta = Settings.getInterval() / 10000;
             try {
-                tile.tile.img.rotation += (delta * dt);
+                tile.tile.rotation += (delta * dt);
             } catch (err) {
                 // skip lost frames if the tile is being updated by the server
             }

--- a/src/templates/updateWindow.html
+++ b/src/templates/updateWindow.html
@@ -23,6 +23,14 @@
 <h1>Important Changes</h1>
 <p>Below are just some of the changes to the module that should be called out. The full changelog is also available
     <a href="https://github.com/kckaiwei/TurnMarker-alt/blob/master/CHANGELOG.md">here</a>.</p>
+<h2>v2.8.0</h2>
+<ul>
+    <li>Add compatibility for Foundry version 0.8.6</li>
+</ul>
+<h2>v2.7.5</h2>
+<ul>
+    <li>Add Savage Worlds Adventurer Edition support (SWADE)</li>
+</ul>
 <h2>v2.7.4</h2>
 <ul>
     <li>Fixed marker sizing issues for non-square tokens on grid/gridless maps</li>
@@ -31,17 +39,6 @@
 <h2>v2.7.3</h2>
 <ul>
     <li>Fixed tile deletion issue in different scenes</li>
-</ul>
-<h2>v2.7.2</h2>
-<ul>
-    <li>Fixed marker in wrong location after reloading</li>
-    <li>Fixed marker not pausing with game</li>
-    <li>Marker visibilities are now tied to vision</li>
-</ul>
-<h2>v2.7.1</h2>
-<ul>
-    <li>Fixing ghosting issues with some start markers</li>
-    <li>Fixing turn marker showing when out of combat</li>
 </ul>
 <p style="display: flex; flex-flow: row nowrap; align-items: center; justify-content: flex-start;"><input
         type="checkbox" class='show-again' id="welcome-screen-show-again" /> <label


### PR DESCRIPTION
Add compatibility for 0.8.6

Main changes, creating Tiles is different, `new Tile()` requires TileDocument, which I'm not too sure on how to pull yet, so using `createEmbeddedDocuments` for now. (It replaced createEmbeddedEntity)

TileData is a thing as well, so that's one more layer when pulling data from tiles, such as `id`

We grab placeables using background instead now. There's a foreground and background layer. We're interested in using the background layer for now.