### PR TITLE
Added null or undefined check in stopAllAnimation.

### DIFF
--- a/src/scripts/markeranimation.js
+++ b/src/scripts/markeranimation.js
@@ -28,10 +28,12 @@ export class MarkerAnimation {
     }
 
     static stopAllAnimation() {
-        for (const [key, value] of Object.entries(this.animators)) {
-            canvas.app.ticker.remove(this.animators[key]);
+        if (this.animators) {
+            for (const [key, value] of Object.entries(this.animators)) {
+                canvas.app.ticker.remove(this.animators[key]);
+            }
+            this.animators = {};
         }
-        this.animators = {};
     }
 
     /**


### PR DESCRIPTION
Checking this.animators for null or undefined before attempting to remove turn marker animations.
This.animators is undefined before the first combat in session has been initiated, but stopAllAnimations still gets called when game pauses and throws an error in console (does not break module functionality).