### PR TITLE
When ending combat prevent error message

### DIFF
--- a/src/scripts/markeranimation.js
+++ b/src/scripts/markeranimation.js
@@ -44,7 +44,7 @@ export class MarkerAnimation {
     static stopAllAnimationGM() {
         MarkerAnimation.stopAllAnimation()
         game.socket.emit(socketName, {
-            stopAllAnimation: marker_type
+            stopAllAnimation: true
         });
     }
 

--- a/src/scripts/turnmarker.js
+++ b/src/scripts/turnmarker.js
@@ -71,8 +71,10 @@ Hooks.on("renderCombatTracker", async (combatTracker, update) => {
 });
 
 Hooks.on('deleteCombat', async () => {
-    await Marker.clearAllMarkers();
-    MarkerAnimation.stopAllAnimationGM();
+    if (game.user.isGM && game.userId == firstGM()) {
+        await Marker.clearAllMarkers();
+        MarkerAnimation.stopAllAnimationGM();
+    }
 });
 
 Hooks.on('updateToken', async (tokenDoc, updateData, diff, id) => {


### PR DESCRIPTION
When hook deleteCombat is called, players receive the follow JavaScript error
ReferenceError: marker_type is not defined

Removing this error allows each player to call stopAllAnimation which triggers multiple delete requests for the same tile so only trigger for one active GM player